### PR TITLE
Cleanup

### DIFF
--- a/.idea/dictionaries/pavel.xml
+++ b/.idea/dictionaries/pavel.xml
@@ -229,7 +229,6 @@
       <w>vssc</w>
       <w>weakref</w>
       <w>wireshark</w>
-      <w>wkspc</w>
       <w>woah</w>
       <w>wrkspc</w>
       <w>xbee</w>

--- a/.idea/dictionaries/pavel.xml
+++ b/.idea/dictionaries/pavel.xml
@@ -229,7 +229,9 @@
       <w>vssc</w>
       <w>weakref</w>
       <w>wireshark</w>
+      <w>wkspc</w>
       <w>woah</w>
+      <w>wrkspc</w>
       <w>xbee</w>
       <w>zubax</w>
     </words>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,11 +65,11 @@ for:
       - python --version
     test_script:
       # GNU/Linux test.
-      - sh: nox --non-interactive --error-on-missing-interpreters --session test test_eol lint --python $PYTHON
+      - sh: nox --non-interactive --error-on-missing-interpreters --session test test_eol pristine lint --python $PYTHON
       # skip macOS docs build
       - sh: 'if [ "$APPVEYOR_BUILD_WORKER_IMAGE" != "macos" ]; then nox --non-interactive --session docs; fi'
       # MS Windows test.
-      - cmd: nox --forcecolor --non-interactive --error-on-missing-interpreters --session test test_eol lint
+      - cmd: nox --forcecolor --non-interactive --error-on-missing-interpreters --session test test_eol pristine lint
       # Shared test for all platforms.
       - git clone https://github.com/OpenCyphal/public_regulated_data_types .dsdl-test
       - python -c "import pydsdl; pydsdl.read_namespace('.dsdl-test/uavcan', [])"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,11 +65,11 @@ for:
       - python --version
     test_script:
       # GNU/Linux test.
-      - sh: nox --non-interactive --error-on-missing-interpreters --session test lint --python $PYTHON
+      - sh: nox --non-interactive --error-on-missing-interpreters --session test test_eol lint --python $PYTHON
       # skip macOS docs build
       - sh: 'if [ "$APPVEYOR_BUILD_WORKER_IMAGE" != "macos" ]; then nox --non-interactive --session docs; fi'
       # MS Windows test.
-      - cmd: nox --forcecolor --non-interactive --error-on-missing-interpreters --session test lint
+      - cmd: nox --forcecolor --non-interactive --error-on-missing-interpreters --session test test_eol lint
       # Shared test for all platforms.
       - git clone https://github.com/OpenCyphal/public_regulated_data_types .dsdl-test
       - python -c "import pydsdl; pydsdl.read_namespace('.dsdl-test/uavcan', [])"

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import nox
 
 
-PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
 """The newest supported Python shall be listed LAST."""
 
 nox.options.error_on_external_run = True
@@ -48,9 +48,9 @@ def test(session):
     session.log("Using the newest supported Python: %s", is_latest_python(session))
     session.install("-e", ".")
     session.install(
-        "pytest          ~= 7.0",
-        "pytest-randomly ~= 3.10",
-        "coverage        ~= 6.2",
+        "pytest          ~= 7.3",
+        "pytest-randomly ~= 3.12",
+        "coverage        ~= 7.2",
     )
     session.run("coverage", "run", "-m", "pytest")
     session.run("coverage", "report", "--fail-under=95")
@@ -60,12 +60,20 @@ def test(session):
         session.log(f"OPEN IN WEB BROWSER: file://{report_file}")
 
 
+@nox.session(python=["3.6", "3.7"])
+def test_eol(session):
+    """This is a minimal test session for those old Pythons that have EOLed."""
+    session.install("-e", ".")
+    session.install("pytest")
+    session.run("pytest")
+
+
 @nox.session(python=PYTHONS, reuse_venv=True)
 def lint(session):
     session.log("Using the newest supported Python: %s", is_latest_python(session))
     session.install(
-        "mypy   == 0.942",
-        "pylint == 2.13.*",
+        "mypy   ~= 1.2.0",
+        "pylint ~= 2.17.2",
     )
     session.run(
         "mypy",
@@ -84,7 +92,7 @@ def lint(session):
         },
     )
     if is_latest_python(session):
-        session.install("black == 22.*")
+        session.install("black ~= 23.3")
         session.run("black", "--check", ".")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,7 @@
 import os
 import shutil
 from pathlib import Path
+from functools import partial
 import nox
 
 
@@ -66,6 +67,18 @@ def test_eol(session):
     session.install("-e", ".")
     session.install("pytest")
     session.run("pytest")
+
+
+@nox.session(python=PYTHONS)
+def pristine(session):
+    """
+    Install the library into a pristine environment and ensure that it is importable.
+    This is needed to catch errors caused by accidental reliance on test dependencies in the main codebase.
+    """
+    exe = partial(session.run, "python", "-c", silent=True)
+    session.cd(session.create_tmp())  # Change the directory to reveal spurious dependencies from the project root.
+    session.install(f"{ROOT_DIR}")  # Testing bare installation first.
+    exe("import pydsdl")
 
 
 @nox.session(python=PYTHONS, reuse_venv=True)

--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -4,8 +4,8 @@
 
 # pylint: disable=wrong-import-position
 
-import os as _os
 import sys as _sys
+from pathlib import Path as _Path
 
 __version__ = "1.19.0"
 __version_info__ = tuple(map(int, __version__.split(".")[:3]))
@@ -22,7 +22,7 @@ __email__ = "maintainers@opencyphal.org"
 # to import stuff dynamically after the initialization is finished (e.g., function-local imports won't be
 # able to reach the third-party stuff), but we don't care.
 _original_sys_path = _sys.path
-_sys.path = [_os.path.join(_os.path.dirname(__file__), "third_party")] + _sys.path
+_sys.path = [str(_Path(__file__).parent / "third_party")] + _sys.path
 
 # Never import anything that is not available here - API stability guarantees are only provided for the exposed items.
 from ._namespace import read_namespace as read_namespace

--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -7,7 +7,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 __version_info__ = tuple(map(int, __version__.split(".")[:3]))
 __license__ = "MIT"
 __author__ = "OpenCyphal"

--- a/pydsdl/_bit_length_set/_symbolic.py
+++ b/pydsdl/_bit_length_set/_symbolic.py
@@ -132,7 +132,7 @@ class ConcatenationOperator(Operator):
         mods = [ch.modulo(divisor) for ch in self._children]
         prod = itertools.product(*mods)
         sums = set(map(sum, prod))
-        return {typing.cast(int, x) % divisor for x in sums}
+        return {x % divisor for x in sums}
 
     @property
     def min(self) -> int:

--- a/pydsdl/_dsdl_definition.py
+++ b/pydsdl/_dsdl_definition.py
@@ -40,7 +40,7 @@ class DSDLDefinition:
             self._text = str(f.read())
 
         # Checking the sanity of the root directory path - can't contain separators
-        if CompositeType.NAME_COMPONENT_SEPARATOR in str(self._root_namespace_path.name):
+        if CompositeType.NAME_COMPONENT_SEPARATOR in self._root_namespace_path.name:
             raise FileNameFormatError("Invalid namespace name", path=self._root_namespace_path)
 
         # Determining the relative path within the root namespace directory

--- a/pydsdl/_dsdl_definition.py
+++ b/pydsdl/_dsdl_definition.py
@@ -2,7 +2,6 @@
 # This software is distributed under the terms of the MIT License.
 # Author: Pavel Kirienko <pavel@opencyphal.org>
 
-import os
 import time
 from typing import Iterable, Callable, Optional, List
 import logging
@@ -41,21 +40,14 @@ class DSDLDefinition:
             self._text = str(f.read())
 
         # Checking the sanity of the root directory path - can't contain separators
-        if CompositeType.NAME_COMPONENT_SEPARATOR in os.path.split(self._root_namespace_path)[-1]:
+        if CompositeType.NAME_COMPONENT_SEPARATOR in str(self._root_namespace_path.name):
             raise FileNameFormatError("Invalid namespace name", path=self._root_namespace_path)
 
         # Determining the relative path within the root namespace directory
-        relative_path = str(
-            os.path.join(
-                os.path.split(self._root_namespace_path)[-1],
-                self._file_path.relative_to(self._root_namespace_path),
-            )
-        )
-
-        relative_directory, basename = [str(x) for x in os.path.split(relative_path)]  # type: str, str
+        relative_path = self._root_namespace_path.name / self._file_path.relative_to(self._root_namespace_path)
 
         # Parsing the basename, e.g., 434.GetTransportStatistics.0.1.dsdl
-        basename_components = basename.split(".")[:-1]
+        basename_components = relative_path.name.split(".")[:-1]
         str_fixed_port_id: Optional[str] = None
         if len(basename_components) == 4:
             str_fixed_port_id, short_name, str_major_version, str_minor_version = basename_components
@@ -86,11 +78,10 @@ class DSDLDefinition:
             raise FileNameFormatError("Could not parse the version numbers", path=self._file_path) from None
 
         # Finally, constructing the name
-        namespace_components = list(relative_directory.strip(os.sep).split(os.sep))
+        namespace_components = list(relative_path.parent.parts)
         for nc in namespace_components:
             if CompositeType.NAME_COMPONENT_SEPARATOR in nc:
                 raise FileNameFormatError(f"Invalid name for namespace component: {nc!r}", path=self._file_path)
-
         self._name: str = CompositeType.NAME_COMPONENT_SEPARATOR.join(namespace_components + [str(short_name)])
 
         self._cached_type: Optional[CompositeType] = None

--- a/pydsdl/_namespace.py
+++ b/pydsdl/_namespace.py
@@ -577,6 +577,31 @@ def _unittest_dsdl_definition_constructor() -> None:
         (root / "nested/super.bad/Unreachable.1.0.dsdl").unlink()
 
 
+def _unittest_dsdl_definition_constructor_legacy() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as directory:
+        di = Path(directory).resolve()
+        root = di / "foo"
+        root.mkdir()
+        (root / "123.Qwerty.123.234.uavcan").write_text("# TEST A")
+        dsdl_defs = _construct_dsdl_definitions_from_namespace(root)
+        print(dsdl_defs)
+        lut = {x.full_name: x for x in dsdl_defs}  # type: Dict[str, _dsdl_definition.DSDLDefinition]
+        assert len(lut) == 1
+        t = lut["foo.Qwerty"]
+        assert t.file_path == root / "123.Qwerty.123.234.uavcan"
+        assert t.has_fixed_port_id
+        assert t.fixed_port_id == 123
+        assert t.text == "# TEST A"
+        assert t.version.major == 123
+        assert t.version.minor == 234
+        assert t.name_components == ["foo", "Qwerty"]
+        assert t.short_name == "Qwerty"
+        assert t.root_namespace == "foo"
+        assert t.full_namespace == "foo"
+
+
 def _unittest_common_usage_errors() -> None:
     import tempfile
 

--- a/pydsdl/_namespace.py
+++ b/pydsdl/_namespace.py
@@ -259,18 +259,12 @@ def _ensure_no_name_collisions(
         for lu in lookup_definitions:
             lu_full_namespace_period = lu.full_namespace.lower() + "."
             lu_full_name_period = lu.full_name.lower() + "."
-            """
-            This is to allow the following messages to coexist happily:
-
-            zubax/noncolliding/iceberg/Ice.0.1.dsdl
-            zubax/noncolliding/Iceb.0.1.dsdl
-
-            The following is still not allowed:
-
-            zubax/colliding/iceberg/Ice.0.1.dsdl
-            zubax/colliding/Iceberg.0.1.dsdl
-
-            """
+            # This is to allow the following messages to coexist happily:
+            #   zubax/non_colliding/iceberg/Ice.0.1.dsdl
+            #   zubax/non_colliding/IceB.0.1.dsdl
+            # The following is still not allowed:
+            #   zubax/colliding/iceberg/Ice.0.1.dsdl
+            #   zubax/colliding/Iceberg.0.1.dsdl
             if tg.full_name != lu.full_name and tg.full_name.lower() == lu.full_name.lower():
                 raise DataTypeNameCollisionError(
                     "Full name of this definition differs from %s only by letter case, "

--- a/pydsdl/_parser.py
+++ b/pydsdl/_parser.py
@@ -2,12 +2,12 @@
 # This software is distributed under the terms of the MIT License.
 # Author: Pavel Kirienko <pavel@opencyphal.org>
 
-import os
 import typing
 import logging
 import itertools
 import functools
 import fractions
+from pathlib import Path
 from typing import List, Tuple
 import parsimonious
 from parsimonious.nodes import Node as _Node
@@ -89,8 +89,7 @@ class StatementStreamProcessor:
 
 @functools.lru_cache(None)
 def _get_grammar() -> parsimonious.Grammar:
-    with open(os.path.join(os.path.dirname(__file__), "grammar.parsimonious")) as _grammar_file:
-        return parsimonious.Grammar(_grammar_file.read())  # type: ignore
+    return parsimonious.Grammar((Path(__file__).parent / "grammar.parsimonious").read_text())  # type: ignore
 
 
 _logger = logging.getLogger(__name__)

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -1131,7 +1131,7 @@ def _unittest_parse_namespace(wrkspc: Workspace) -> None:
     (wrkspc.directory / "zubax/COLLIDING/300.Iceberg.30.0.dsdl").unlink()
     try:
         ((wrkspc.directory / "zubax/colliding/300.Iceberg.30.0.dsdl")).unlink()
-    except FileNotFoundError:
+    except FileNotFoundError:  # pragma: no cover
         pass  # We're running on a platform where paths are not case-sensitive.
     wrkspc.new(
         "zubax/noncolliding/iceberg/Ice.1.0.dsdl",

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ show_error_context     = True
 strict_equality        = True
 implicit_reexport      = False
 incremental            = False
+exclude                = pydsdl/third_party
 
 [mypy-pytest.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,6 @@
 # Author: Pavel Kirienko <pavel@opencyphal.org>
 # type: ignore
 
-import sys
 import setuptools
-
-if int(setuptools.__version__.split(".")[0]) < 30:
-    print(
-        "A newer version of setuptools is required. The current version does not support declarative config.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
 
 setuptools.setup()


### PR DESCRIPTION
- Update the development-related dependencies.

- Demote Python v3.6 and v3.7 to minimally supported versions (no linting, no coverage).

- Fix https://github.com/OpenCyphal/pydsdl/issues/84. `os.path` is no longer used, and dependency on the text representations of paths is minimized.

- Refactor the test suite to eliminate the global state and simplify the internal APIs.

- The library now logs a warning when it encounters a `*.uavcan` file, suggesting renaming it to `*.dsdl`. See https://forum.opencyphal.org/t/uavcan-file-extension/438/8. There are no plans to remove support for `*.uavcan` but it is desirable to push users towards consistency.

- Bump the minor version.

