### PR TITLE
Allow relative target paths

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -7,7 +7,7 @@
 import sys as _sys
 from pathlib import Path as _Path
 
-__version__ = "1.21.1"
+__version__ = "1.22.0"
 __version_info__ = tuple(map(int, __version__.split(".")[:3]))
 __license__ = "MIT"
 __author__ = "OpenCyphal"

--- a/pydsdl/_dsdl.py
+++ b/pydsdl/_dsdl.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Callable, Iterable, TypeVar, List, Tuple
+from typing import Any, Callable, Iterable, List, Tuple, TypeVar
 
 from ._serializable import CompositeType, Version
 
@@ -103,6 +103,14 @@ class ReadableDSDLFile(DSDLFile):
     """
     A DSDL file that can construct a composite type from its contents.
     """
+
+    @property
+    @abstractmethod
+    def file_path(self) -> Path:
+        """
+        Path to an existing DSDL file on the filesystem.
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def read(

--- a/pydsdl/_namespace_reader.py
+++ b/pydsdl/_namespace_reader.py
@@ -201,9 +201,7 @@ def _unittest_namespace_reader_read_definitions_multiple_no_load(temp_dsdl_facto
         temp_dsdl_factory.new_file(Path("root", "ns", "Tacoma.1.0.dsdl"), "@sealed"),
         temp_dsdl_factory.new_file(Path("root", "ns", "Rainer.1.0.dsdl"), "@sealed"),
         temp_dsdl_factory.new_file(Path("root", "ns", "Baker.1.0.dsdl"), "@sealed"),
-        Path(
-            "root", "ns", "Shasta.1.0.dsdl"
-        ),  # since this isn't in the transitive closure of target dependencies it will
+        temp_dsdl_factory.new_file(Path("root", "ns", "Shasta.1.0.dsdl"), "@sealed"),
         # never be read thus it will not be an error that it does not exist.
     ]
 


### PR DESCRIPTION
Fix for issue #109. This relaxes some logic that required existing paths before creating a DSDLFile abstraction while adding a requirement that ReadableDSDLFile(s) are created with files that exist (i.e. it can't be "readable" if it doesn't exist). At the same time, we clarified (and fixed) the difference between the `root_namespace_directories_or_names` and `lookup_directories arguments` of read_files. Our new guidance is to dis-use `lookup_directories` unless there is a need to separate target lookup paths from dependent type look up paths. This was an unstated design goal that I forgot about and subsequently mis-implemented. This does change the behaviour of the API slightly which is why I've bumped the minor version instead of just the patch.